### PR TITLE
Add parsing for 434001 and 434003

### DIFF
--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -698,9 +698,17 @@ processors:
       separator: ",\\s+"
       ignore_missing: true
   - dissect:
+      if: "ctx._temp_.cisco.message_id == '434001'"
+      field: "message"
+      pattern: "SFR card not up and fail-close mode used, %{event.action}ping %{network.protocol} packet from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
+  - dissect:
       if: "ctx._temp_.cisco.message_id == '434002'"
       field: "message"
       pattern: "SFR requested to %{event.action} %{network.protocol} packet from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '434003'"
+      field: "message"
+      pattern: "SFR requested to %{event.action} %{network.protocol} connection from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '434004'"
       field: "message"
@@ -740,7 +748,7 @@ processors:
       - "^(Group = %{IP}, )?(IP = %{IP:source.address}, )?%{GREEDYDATA:event.reason}$"
    # Handle ecs action outcome protocol
   - set:
-      if: '["434002", "434004"].contains(ctx._temp_.cisco.message_id)'
+      if: '["434002", "434003", "434004"].contains(ctx._temp_.cisco.message_id)'
       field: "event.outcome"
       value: "unknown"
   - set:


### PR DESCRIPTION
- Enhancement

## What does this PR do?
This PR adds parsing for Cisco ASA 434001 and 434003 using the precise style currently used for parsing Cisco ASA 434002.

## Why is it important?
We need parsing for ASA 434001, 434002, and 434003; right now only 434002 is supported, despite the others being substantially similar dissections.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ 
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
The PR uses the patterns specified here: https://www.cisco.com/c/en/us/td/docs/security/asa/syslog/b_syslog/syslog-messages-400000-to-450001.html#con_7199521.
For testing the actual messages, these are sample logs:
For 434001:
<13>Apr 26 2022 10:24:37: %ASA-4-434001: SFR card not up and fail-close mode used, dropping TCP packet from outside:54.239.28.85/443 to Inside:10.12.128.89/57388

For 434003:
<13>May 30 2019 09:18:59: %ASA-4-434003: SFR requested to reset TCP connection from outside:54.239.28.85/443 to Inside:10.12.128.89/57388

Ideally a test would send these messages through filebeat with the Cisco ASA module enabled, although in this case the change is small enough to be visually inspected and compared with the working 434002 dissection that neighbors the changes and the Cisco specified log patterns from https://www.cisco.com/c/en/us/td/docs/security/asa/syslog/b_syslog/syslog-messages-400000-to-450001.html#con_7199521.